### PR TITLE
Fix broken AWS documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ s3gopolicy
 Authenticating Requests in Browser-Based Uploads Using POST (AWS Signature Version 2 or 4) for golang
 
 ## AWS Signature Version v4
-https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
+https://docs.aws.amazon.com/AmazonS3/latest/developerguide/sigv4-authentication-HTTPPOST.html
 
 ### Install
 
@@ -111,7 +111,7 @@ func openFileUpload(url, file string, policies s3gopolicy.UploadPolicies) (err e
 ```
 
 ## v2
-http://docs.aws.amazon.com/ja_jp/AmazonS3/latest/dev/UsingHTTPPOST.html
+https://docs.aws.amazon.com/AmazonS3/latest/developerguide/UsingHTTPPOST.html
 
 ### Install
 


### PR DESCRIPTION
## 概要
READMEのAWSドキュメントリンク2件がリンク切れしていたのを修正します(PR #6 に含める予定だったコミットがマージ前に反映されず漏れていた分です)。

## 変更内容
- SigV4: `ja_jp/.../API/sigv4-authentication-HTTPPOST.html`(404)→ 現存する英語版 `developerguide/sigv4-authentication-HTTPPOST.html`
- SigV2: `ja_jp/.../dev/UsingHTTPPOST.html`(ガイドトップにリダイレクト)→ 現存する英語版 `developerguide/UsingHTTPPOST.html`

日本語版(ja_jp)のページは両方とも消失していたため、英語版のcanonical URL(200 OK・ページタイトル一致を確認済み)に差し替えています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)