### PR TITLE
デフォルトアップロードURLをhttpsにする

### DIFF
--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -53,6 +53,7 @@ const expirationHour = 1 * time.Hour
 // defaultUploadURL builds the virtual-hosted style upload URL.
 // ドットを含むバケット名は *.s3.amazonaws.com のワイルドカード証明書に一致せず
 // httpsでは証明書エラーになるため、httpのままにする。
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 func defaultUploadURL(bucketName string) string {
 	if strings.Contains(bucketName, ".") {
 		return fmt.Sprintf("http://%s.s3.amazonaws.com/", bucketName)

--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -50,7 +50,15 @@ type PolicyJSON struct {
 const expirationTimeFormat = "2006-01-02T15:04:05ZZ07:00"
 const expirationHour = 1 * time.Hour
 
-const defaultUploadURLFormat = "https://%s.s3.amazonaws.com/" // <bucketName>
+// defaultUploadURL builds the virtual-hosted style upload URL.
+// ドットを含むバケット名は *.s3.amazonaws.com のワイルドカード証明書に一致せず
+// httpsでは証明書エラーになるため、httpのままにする。
+func defaultUploadURL(bucketName string) string {
+	if strings.Contains(bucketName, ".") {
+		return fmt.Sprintf("http://%s.s3.amazonaws.com/", bucketName)
+	}
+	return fmt.Sprintf("https://%s.s3.amazonaws.com/", bucketName)
+}
 
 // NowTime mockable time.Now()
 var NowTime = func() time.Time {
@@ -86,7 +94,7 @@ func CreatePolicies(awsCredentials AWSCredentials, fileInfo UploadConfig) (Uploa
 
 	uploadURL := fileInfo.UploadURL
 	if uploadURL == "" {
-		uploadURL = fmt.Sprintf(defaultUploadURLFormat, fileInfo.BucketName)
+		uploadURL = defaultUploadURL(fileInfo.BucketName)
 	}
 	return UploadPolicies{
 		URL: uploadURL,

--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -50,7 +50,7 @@ type PolicyJSON struct {
 const expirationTimeFormat = "2006-01-02T15:04:05ZZ07:00"
 const expirationHour = 1 * time.Hour
 
-const defaultUploadURLFormat = "http://%s.s3.amazonaws.com/" // <bucketName>
+const defaultUploadURLFormat = "https://%s.s3.amazonaws.com/" // <bucketName>
 
 // NowTime mockable time.Now()
 var NowTime = func() time.Time {

--- a/v2/s3gopolicy_test.go
+++ b/v2/s3gopolicy_test.go
@@ -33,3 +33,29 @@ func TestCreatePolicies(t *testing.T) {
 	as.Equal("FPI4mtudW6IZjj05ZsOWvug3TZA=",
 		policies.Form.Signature)
 }
+
+func TestCreatePoliciesDefaultUploadURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucketName string
+		wantURL    string
+	}{
+		{"bucket without dots uses https", "examplebucket", "https://examplebucket.s3.amazonaws.com/"},
+		{"bucket with dots keeps http", "test.bucket", "http://test.bucket.s3.amazonaws.com/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+				AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
+				AWSSecretKeyID: "AWS_SECRET_KEY_ID",
+			}, s3gopolicy.UploadConfig{
+				BucketName:  tt.bucketName,
+				ObjectKey:   "files/image1.png",
+				ContentType: "image/png",
+				FileSize:    2000,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantURL, policies.URL)
+		})
+	}
+}

--- a/v4/s3gopolicy.go
+++ b/v4/s3gopolicy.go
@@ -58,7 +58,7 @@ const (
 	algorithm                = "AWS4-HMAC-SHA256"
 	serviceName              = "s3"
 
-	defaultUploadURLFormat = "http://%s.s3.amazonaws.com/" // <bucketName>
+	defaultUploadURLFormat = "https://%s.s3.amazonaws.com/" // <bucketName>
 	defaultExpirationHour  = 1 * time.Hour
 )
 

--- a/v4/s3gopolicy.go
+++ b/v4/s3gopolicy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -58,9 +59,18 @@ const (
 	algorithm                = "AWS4-HMAC-SHA256"
 	serviceName              = "s3"
 
-	defaultUploadURLFormat = "https://%s.s3.amazonaws.com/" // <bucketName>
-	defaultExpirationHour  = 1 * time.Hour
+	defaultExpirationHour = 1 * time.Hour
 )
+
+// defaultUploadURL builds the virtual-hosted style upload URL.
+// ドットを含むバケット名は *.s3.amazonaws.com のワイルドカード証明書に一致せず
+// httpsでは証明書エラーになるため、httpのままにする。
+func defaultUploadURL(bucketName string) string {
+	if strings.Contains(bucketName, ".") {
+		return fmt.Sprintf("http://%s.s3.amazonaws.com/", bucketName)
+	}
+	return fmt.Sprintf("https://%s.s3.amazonaws.com/", bucketName)
+}
 
 // NowTime mockable time.Now()
 var NowTime = func() time.Time {
@@ -86,7 +96,7 @@ func CreatePolicies(awsCredentials AWSCredentials, uploadConfig UploadConfig) (U
 
 	uploadURL := uploadConfig.UploadURL
 	if uploadURL == "" {
-		uploadURL = fmt.Sprintf(defaultUploadURLFormat, uploadConfig.BucketName)
+		uploadURL = defaultUploadURL(uploadConfig.BucketName)
 	}
 	form := map[string]string{
 		"key":              uploadConfig.ObjectKey,

--- a/v4/s3gopolicy.go
+++ b/v4/s3gopolicy.go
@@ -65,6 +65,7 @@ const (
 // defaultUploadURL builds the virtual-hosted style upload URL.
 // ドットを含むバケット名は *.s3.amazonaws.com のワイルドカード証明書に一致せず
 // httpsでは証明書エラーになるため、httpのままにする。
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
 func defaultUploadURL(bucketName string) string {
 	if strings.Contains(bucketName, ".") {
 		return fmt.Sprintf("http://%s.s3.amazonaws.com/", bucketName)

--- a/v4/s3gopolicy_test.go
+++ b/v4/s3gopolicy_test.go
@@ -43,6 +43,33 @@ func TestCreatePolicies(t *testing.T) {
 		policies.Form["X-Amz-Signature"])
 }
 
+func TestCreatePoliciesDefaultUploadURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		bucketName string
+		wantURL    string
+	}{
+		{"bucket without dots uses https", "examplebucket", "https://examplebucket.s3.amazonaws.com/"},
+		{"bucket with dots keeps http", "test.bucket", "http://test.bucket.s3.amazonaws.com/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+				Region:         "ap-northeast-1",
+				AWSAccessKeyID: "<AWS_ACCESS_KEY_ID>",
+				AWSSecretKeyID: "<AWS_SECRET_KEY_ID>",
+			}, s3gopolicy.UploadConfig{
+				BucketName:  tt.bucketName,
+				ObjectKey:   "files/image1.png",
+				ContentType: "image/png",
+				FileSize:    2000,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURL, policies.URL)
+		})
+	}
+}
+
 func ExampleCreatePolicies() {
 	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
 		Region:         "ap-northeast-1",


### PR DESCRIPTION
## 概要
デフォルトアップロードURL(`defaultUploadURL`)を `http://` から `https://` に変更します(v2/v4両方)。

Closes #9

## 注意事項(非破壊的変更のための対応)
ドットを含むバケット名(例: `test.bucket`)は、virtual-hosted style(`<bucket>.s3.amazonaws.com`)のワイルドカード証明書に一致せずhttpsだと証明書エラーになるため、従来どおり `http://` を維持します。これによりhttpで動いていた既存利用者への破壊的変更を回避しています。

## 変更内容
- ドットを含まないバケット名: `https://<bucket>.s3.amazonaws.com/`
- ドットを含むバケット名: `http://<bucket>.s3.amazonaws.com/`(従来どおり)
- デフォルトURL生成のテストを追加(v2/v4)

## 動作確認
- `go test ./...` パス
- `golangci-lint run ./...` で0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)