### PR TITLE
日時処理をUTCに統一し、expirationのフォーマット不正を修正する

### DIFF
--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -47,7 +47,7 @@ type PolicyJSON struct {
 	Conditions []interface{} `json:"conditions"`
 }
 
-const expirationTimeFormat = "2006-01-02T15:04:05ZZ07:00"
+const expirationTimeFormat = "2006-01-02T15:04:05.000Z"
 const expirationHour = 1 * time.Hour
 
 // defaultUploadURL builds the virtual-hosted style upload URL.
@@ -80,7 +80,7 @@ func CreatePolicies(awsCredentials AWSCredentials, fileInfo UploadConfig) (Uploa
 		}
 	}
 	data, err := json.Marshal(&PolicyJSON{
-		Expiration: NowTime().Add(expirationHour).Format(expirationTimeFormat),
+		Expiration: NowTime().UTC().Add(expirationHour).Format(expirationTimeFormat),
 		Conditions: conditions,
 	})
 	if err != nil {

--- a/v2/s3gopolicy_test.go
+++ b/v2/s3gopolicy_test.go
@@ -28,9 +28,34 @@ func TestCreatePolicies(t *testing.T) {
 
 	fmt.Printf("%#v\n", policies)
 
-	as.Equal("eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMFpaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoiaG9nZWhvZ2VmdWdhZnVnYS5hbWF6b25hd3MuY29tIn0seyJrZXkiOiJmaWxlcy9pbWFnZTEucG5nIn0seyJDb250ZW50LVR5cGUiOiJpbWFnZS9wbmcifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwyMDAwLDIwMDBdXX0=",
+	as.Equal("eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoiaG9nZWhvZ2VmdWdhZnVnYS5hbWF6b25hd3MuY29tIn0seyJrZXkiOiJmaWxlcy9pbWFnZTEucG5nIn0seyJDb250ZW50LVR5cGUiOiJpbWFnZS9wbmcifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwyMDAwLDIwMDBdXX0=",
 		policies.Form.Policy)
-	as.Equal("FPI4mtudW6IZjj05ZsOWvug3TZA=",
+	as.Equal("ToFz/ggBRhVyYBRjUUz718HSLA8=",
+		policies.Form.Signature)
+}
+
+// ローカルタイムがUTC以外でも、UTCで生成した場合と同じ結果になることを確認する
+func TestCreatePoliciesNonUTC(t *testing.T) {
+	as := assert.New(t)
+
+	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
+	s3gopolicy.NowTime = func() time.Time {
+		return time.Date(2016, time.December, 10, 9, 0, 0, 0, jst) // UTCの2016-12-10T00:00:00Zと同時刻
+	}
+
+	policies, _ := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+		AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
+		AWSSecretKeyID: "AWS_SECRET_KEY_ID",
+	}, s3gopolicy.UploadConfig{
+		BucketName:  "hogehogefugafuga.amazonaws.com",
+		ObjectKey:   "files/image1.png",
+		ContentType: "image/png",
+		FileSize:    2000,
+	})
+
+	as.Equal("eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoiaG9nZWhvZ2VmdWdhZnVnYS5hbWF6b25hd3MuY29tIn0seyJrZXkiOiJmaWxlcy9pbWFnZTEucG5nIn0seyJDb250ZW50LVR5cGUiOiJpbWFnZS9wbmcifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwyMDAwLDIwMDBdXX0=",
+		policies.Form.Policy)
+	as.Equal("ToFz/ggBRhVyYBRjUUz718HSLA8=",
 		policies.Form.Signature)
 }
 

--- a/v2/s3gopolicy_test.go
+++ b/v2/s3gopolicy_test.go
@@ -1,22 +1,28 @@
 package s3gopolicy_test
 
 import (
-	"fmt"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/kyokomi/s3gopolicy/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func mockNowTime(t *testing.T, tm time.Time) {
+	orig := s3gopolicy.NowTime
+	s3gopolicy.NowTime = func() time.Time { return tm }
+	t.Cleanup(func() { s3gopolicy.NowTime = orig })
+}
 
 func TestCreatePolicies(t *testing.T) {
 	as := assert.New(t)
 
-	s3gopolicy.NowTime = func() time.Time {
-		return time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC)
-	}
+	mockNowTime(t, time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC))
 
-	policies, _ := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
 		AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
 		AWSSecretKeyID: "AWS_SECRET_KEY_ID",
 	}, s3gopolicy.UploadConfig{
@@ -25,38 +31,47 @@ func TestCreatePolicies(t *testing.T) {
 		ContentType: "image/png",
 		FileSize:    2000,
 	})
-
-	fmt.Printf("%#v\n", policies)
+	require.NoError(t, err)
 
 	as.Equal("eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoiaG9nZWhvZ2VmdWdhZnVnYS5hbWF6b25hd3MuY29tIn0seyJrZXkiOiJmaWxlcy9pbWFnZTEucG5nIn0seyJDb250ZW50LVR5cGUiOiJpbWFnZS9wbmcifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwyMDAwLDIwMDBdXX0=",
 		policies.Form.Policy)
 	as.Equal("ToFz/ggBRhVyYBRjUUz718HSLA8=",
 		policies.Form.Signature)
+
+	policyJSON, err := base64.StdEncoding.DecodeString(policies.Form.Policy)
+	require.NoError(t, err)
+	var policy struct {
+		Expiration string `json:"expiration"`
+	}
+	require.NoError(t, json.Unmarshal(policyJSON, &policy))
+	as.Equal("2016-12-10T01:00:00.000Z", policy.Expiration)
 }
 
-// ローカルタイムがUTC以外でも、UTCで生成した場合と同じ結果になることを確認する
+// NowTimeがUTC以外のタイムゾーンでも、UTCと同じポリシー・署名になることを確認する
 func TestCreatePoliciesNonUTC(t *testing.T) {
-	as := assert.New(t)
+	utcTime := time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC)
+	jstTime := utcTime.In(time.FixedZone("Asia/Tokyo", 9*60*60))
 
-	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
-	s3gopolicy.NowTime = func() time.Time {
-		return time.Date(2016, time.December, 10, 9, 0, 0, 0, jst) // UTCの2016-12-10T00:00:00Zと同時刻
+	createPolicies := func(tm time.Time) s3gopolicy.UploadPolicies {
+		mockNowTime(t, tm)
+		policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+			AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
+			AWSSecretKeyID: "AWS_SECRET_KEY_ID",
+		}, s3gopolicy.UploadConfig{
+			BucketName:  "hogehogefugafuga.amazonaws.com",
+			ObjectKey:   "files/image1.png",
+			ContentType: "image/png",
+			FileSize:    2000,
+		})
+		require.NoError(t, err)
+		return policies
 	}
 
-	policies, _ := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
-		AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
-		AWSSecretKeyID: "AWS_SECRET_KEY_ID",
-	}, s3gopolicy.UploadConfig{
-		BucketName:  "hogehogefugafuga.amazonaws.com",
-		ObjectKey:   "files/image1.png",
-		ContentType: "image/png",
-		FileSize:    2000,
-	})
+	utcPolicies := createPolicies(utcTime)
+	jstPolicies := createPolicies(jstTime)
 
-	as.Equal("eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoiaG9nZWhvZ2VmdWdhZnVnYS5hbWF6b25hd3MuY29tIn0seyJrZXkiOiJmaWxlcy9pbWFnZTEucG5nIn0seyJDb250ZW50LVR5cGUiOiJpbWFnZS9wbmcifSxbImNvbnRlbnQtbGVuZ3RoLXJhbmdlIiwyMDAwLDIwMDBdXX0=",
-		policies.Form.Policy)
-	as.Equal("ToFz/ggBRhVyYBRjUUz718HSLA8=",
-		policies.Form.Signature)
+	assert.Equal(t, utcPolicies.Form.Policy, jstPolicies.Form.Policy)
+	assert.Equal(t, utcPolicies.Form.Signature, jstPolicies.Form.Signature)
 }
 
 func TestCreatePoliciesDefaultUploadURL(t *testing.T) {

--- a/v4/s3gopolicy.go
+++ b/v4/s3gopolicy.go
@@ -81,8 +81,7 @@ var NowTime = func() time.Time {
 // CreatePolicies create amazon s3 to upload policies return
 // https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
 func CreatePolicies(awsCredentials AWSCredentials, uploadConfig UploadConfig) (UploadPolicies, error) {
-	// x-amz-dateとexpirationはUTCであることが要求されるため、credentialや署名キーと
-	// 日付がズレないようにUTCへ変換してから使う
+	// AWS署名の日付とポリシーの日時はUTCで生成する必要がある
 	nowTime := NowTime().UTC()
 	credential := awsCredentials.buildCredential(nowTime)
 	data, err := buildSign(nowTime, credential, uploadConfig)

--- a/v4/s3gopolicy.go
+++ b/v4/s3gopolicy.go
@@ -53,7 +53,7 @@ type PolicyJSON struct {
 }
 
 const (
-	expirationTimeFormat     = "2006-01-02T15:04:05ZZ07:00"
+	expirationTimeFormat     = "2006-01-02T15:04:05.000Z"
 	amzDateISO8601TimeFormat = "20060102T150405Z"
 	shortTimeFormat          = "20060102"
 	algorithm                = "AWS4-HMAC-SHA256"
@@ -81,7 +81,9 @@ var NowTime = func() time.Time {
 // CreatePolicies create amazon s3 to upload policies return
 // https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html
 func CreatePolicies(awsCredentials AWSCredentials, uploadConfig UploadConfig) (UploadPolicies, error) {
-	nowTime := NowTime()
+	// x-amz-dateとexpirationはUTCであることが要求されるため、credentialや署名キーと
+	// 日付がズレないようにUTCへ変換してから使う
+	nowTime := NowTime().UTC()
 	credential := awsCredentials.buildCredential(nowTime)
 	data, err := buildSign(nowTime, credential, uploadConfig)
 	if err != nil {

--- a/v4/s3gopolicy_test.go
+++ b/v4/s3gopolicy_test.go
@@ -2,6 +2,8 @@ package s3gopolicy_test
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -16,10 +18,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mockNowTime(t *testing.T, tm time.Time) {
+	orig := s3gopolicy.NowTime
+	s3gopolicy.NowTime = func() time.Time { return tm }
+	t.Cleanup(func() { s3gopolicy.NowTime = orig })
+}
+
 func TestCreatePolicies(t *testing.T) {
-	s3gopolicy.NowTime = func() time.Time {
-		return time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC)
-	}
+	mockNowTime(t, time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC))
 
 	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
 		Region:         "ap-northeast-1",
@@ -41,34 +47,47 @@ func TestCreatePolicies(t *testing.T) {
 		policies.Form["Policy"])
 	assert.Equal(t, "1d0eb723e5d0c774791c0a2442e9b44ffc400ca573d8566a5c3106ead10abc1e",
 		policies.Form["X-Amz-Signature"])
+
+	policyJSON, err := base64.StdEncoding.DecodeString(policies.Form["Policy"])
+	require.NoError(t, err)
+	var policy struct {
+		Expiration string `json:"expiration"`
+	}
+	require.NoError(t, json.Unmarshal(policyJSON, &policy))
+	assert.Equal(t, "2016-12-10T01:00:00.000Z", policy.Expiration)
 }
 
-// ローカルタイムがUTC以外でも、UTCで生成した場合と同じ結果になることを確認する
+// NowTimeがUTC以外のタイムゾーンでも、UTCと同じポリシー・署名になることを確認する
 func TestCreatePoliciesNonUTC(t *testing.T) {
-	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
-	s3gopolicy.NowTime = func() time.Time {
-		return time.Date(2016, time.December, 10, 9, 0, 0, 0, jst) // UTCの2016-12-10T00:00:00Zと同時刻
+	utcTime := time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC)
+	jstTime := utcTime.In(time.FixedZone("Asia/Tokyo", 9*60*60))
+
+	createPolicies := func(tm time.Time) s3gopolicy.UploadPolicies {
+		mockNowTime(t, tm)
+		policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+			Region:         "ap-northeast-1",
+			AWSAccessKeyID: "<AWS_ACCESS_KEY_ID>",
+			AWSSecretKeyID: "<AWS_SECRET_KEY_ID>",
+		}, s3gopolicy.UploadConfig{
+			UploadURL:   "https://s3-ap-northeast-1.amazonaws.com/test.bucket",
+			BucketName:  "test.bucket",
+			ObjectKey:   "files/kyokomi/test.mov",
+			ContentType: "video/quicktime",
+			FileSize:    113381558,
+			MetaData: map[string]string{
+				"x-amz-meta-fileName": "test.mov",
+			},
+		})
+		require.NoError(t, err)
+		return policies
 	}
 
-	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
-		Region:         "ap-northeast-1",
-		AWSAccessKeyID: "<AWS_ACCESS_KEY_ID>",
-		AWSSecretKeyID: "<AWS_SECRET_KEY_ID>",
-	}, s3gopolicy.UploadConfig{
-		UploadURL:   "https://s3-ap-northeast-1.amazonaws.com/test.bucket",
-		BucketName:  "test.bucket",
-		ObjectKey:   "files/kyokomi/test.mov",
-		ContentType: "video/quicktime",
-		FileSize:    113381558,
-		MetaData: map[string]string{
-			"x-amz-meta-fileName": "test.mov",
-		},
-	})
-	require.NoError(t, err)
+	utcPolicies := createPolicies(utcTime)
+	jstPolicies := createPolicies(jstTime)
 
-	assert.Equal(t, "20161210T000000Z", policies.Form["X-Amz-Date"])
-	assert.Equal(t, "1d0eb723e5d0c774791c0a2442e9b44ffc400ca573d8566a5c3106ead10abc1e",
-		policies.Form["X-Amz-Signature"])
+	assert.Equal(t, utcPolicies.Form["Policy"], jstPolicies.Form["Policy"])
+	assert.Equal(t, utcPolicies.Form["X-Amz-Signature"], jstPolicies.Form["X-Amz-Signature"])
+	assert.Equal(t, "20161210T000000Z", jstPolicies.Form["X-Amz-Date"])
 }
 
 func TestCreatePoliciesDefaultUploadURL(t *testing.T) {

--- a/v4/s3gopolicy_test.go
+++ b/v4/s3gopolicy_test.go
@@ -37,9 +37,37 @@ func TestCreatePolicies(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMFpaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoidGVzdC5idWNrZXQifSx7ImtleSI6ImZpbGVzL2t5b2tvbWkvdGVzdC5tb3YifSx7IkNvbnRlbnQtVHlwZSI6InZpZGVvL3F1aWNrdGltZSJ9LFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLDExMzM4MTU1OCwxMTMzODE1NThdLHsieC1hbXotY3JlZGVudGlhbCI6Ilx1MDAzY0FXU19BQ0NFU1NfS0VZX0lEXHUwMDNlLzIwMTYxMjEwL2FwLW5vcnRoZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LHsieC1hbXotYWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsieC1hbXotZGF0ZSI6IjIwMTYxMjEwVDAwMDAwMFoifSx7IngtYW16LW1ldGEtZmlsZU5hbWUiOiJ0ZXN0Lm1vdiJ9XX0=",
+	assert.Equal(t, "eyJleHBpcmF0aW9uIjoiMjAxNi0xMi0xMFQwMTowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6W3siYnVja2V0IjoidGVzdC5idWNrZXQifSx7ImtleSI6ImZpbGVzL2t5b2tvbWkvdGVzdC5tb3YifSx7IkNvbnRlbnQtVHlwZSI6InZpZGVvL3F1aWNrdGltZSJ9LFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLDExMzM4MTU1OCwxMTMzODE1NThdLHsieC1hbXotY3JlZGVudGlhbCI6Ilx1MDAzY0FXU19BQ0NFU1NfS0VZX0lEXHUwMDNlLzIwMTYxMjEwL2FwLW5vcnRoZWFzdC0xL3MzL2F3czRfcmVxdWVzdCJ9LHsieC1hbXotYWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsieC1hbXotZGF0ZSI6IjIwMTYxMjEwVDAwMDAwMFoifSx7IngtYW16LW1ldGEtZmlsZU5hbWUiOiJ0ZXN0Lm1vdiJ9XX0=",
 		policies.Form["Policy"])
-	assert.Equal(t, "21678aaeddd0c8f3082c891321c18d89e4007b0ca20f2909268a87f0bf2522e9",
+	assert.Equal(t, "1d0eb723e5d0c774791c0a2442e9b44ffc400ca573d8566a5c3106ead10abc1e",
+		policies.Form["X-Amz-Signature"])
+}
+
+// ローカルタイムがUTC以外でも、UTCで生成した場合と同じ結果になることを確認する
+func TestCreatePoliciesNonUTC(t *testing.T) {
+	jst := time.FixedZone("Asia/Tokyo", 9*60*60)
+	s3gopolicy.NowTime = func() time.Time {
+		return time.Date(2016, time.December, 10, 9, 0, 0, 0, jst) // UTCの2016-12-10T00:00:00Zと同時刻
+	}
+
+	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+		Region:         "ap-northeast-1",
+		AWSAccessKeyID: "<AWS_ACCESS_KEY_ID>",
+		AWSSecretKeyID: "<AWS_SECRET_KEY_ID>",
+	}, s3gopolicy.UploadConfig{
+		UploadURL:   "https://s3-ap-northeast-1.amazonaws.com/test.bucket",
+		BucketName:  "test.bucket",
+		ObjectKey:   "files/kyokomi/test.mov",
+		ContentType: "video/quicktime",
+		FileSize:    113381558,
+		MetaData: map[string]string{
+			"x-amz-meta-fileName": "test.mov",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "20161210T000000Z", policies.Form["X-Amz-Date"])
+	assert.Equal(t, "1d0eb723e5d0c774791c0a2442e9b44ffc400ca573d8566a5c3106ead10abc1e",
 		policies.Form["X-Amz-Signature"])
 }
 


### PR DESCRIPTION
## 概要
日時処理をUTCベースに統一し、expirationのフォーマット不正を修正します。

Closes #7

## 変更内容
- expirationの時刻レイアウトを仕様どおりのISO8601 GMT形式 `"2006-01-02T15:04:05.000Z"` に修正(v2/v4)。従来は `"...T01:00:00ZZ"`(UTC時)や `"...Z+09:00"`(ローカルタイム時)という不正な形式だった
- v4の `x-amz-date` と `expiration` をUTCベースに統一。従来はcredential・署名キーだけUTCで、ローカルタイムがUTC以外だと日付がズレてS3に拒否されうる状態だった(JSTなら0時〜9時)
- テスト追加: UTCとJSTのNowTimeで同じポリシー・署名になることの検証、expirationのフォーマット検証

## 動作確認
- `go test ./...` / `golangci-lint run ./...` パス