### PR TITLE
v2: MetaDataをUploadPoliciesで返してフォーム送信できるようにする

### DIFF
--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -30,9 +30,7 @@ type UploadConfig struct {
 type UploadPolicies struct {
 	URL  string
 	Form PoliciesForm
-	// MetaData is x-amz-meta-* fields included in the policy conditions.
-	// ポリシーのconditionsに含まれるため、アップロード時はFormの各フィールドと
-	// あわせてこれらもフォームフィールドとして送信する必要がある
+	// MetaData is the signed x-amz-meta-* fields to send as form fields along with Form.
 	MetaData []map[string]string
 }
 

--- a/v2/s3gopolicy.go
+++ b/v2/s3gopolicy.go
@@ -30,6 +30,10 @@ type UploadConfig struct {
 type UploadPolicies struct {
 	URL  string
 	Form PoliciesForm
+	// MetaData is x-amz-meta-* fields included in the policy conditions.
+	// ポリシーのconditionsに含まれるため、アップロード時はFormの各フィールドと
+	// あわせてこれらもフォームフィールドとして送信する必要がある
+	MetaData []map[string]string
 }
 
 // PoliciesForm is upload policies formData
@@ -106,5 +110,6 @@ func CreatePolicies(awsCredentials AWSCredentials, fileInfo UploadConfig) (Uploa
 			Signature:      signature,
 			Policy:         policy,
 		},
+		MetaData: fileInfo.MetaData,
 	}, nil
 }

--- a/v2/s3gopolicy_test.go
+++ b/v2/s3gopolicy_test.go
@@ -74,7 +74,6 @@ func TestCreatePoliciesNonUTC(t *testing.T) {
 	assert.Equal(t, utcPolicies.Form.Signature, jstPolicies.Form.Signature)
 }
 
-// MetaDataはポリシーのconditionsに含まれるため、フォーム送信用にUploadPoliciesでも返されることを確認する
 func TestCreatePoliciesWithMetaData(t *testing.T) {
 	as := assert.New(t)
 

--- a/v2/s3gopolicy_test.go
+++ b/v2/s3gopolicy_test.go
@@ -74,6 +74,38 @@ func TestCreatePoliciesNonUTC(t *testing.T) {
 	assert.Equal(t, utcPolicies.Form.Signature, jstPolicies.Form.Signature)
 }
 
+// MetaDataはポリシーのconditionsに含まれるため、フォーム送信用にUploadPoliciesでも返されることを確認する
+func TestCreatePoliciesWithMetaData(t *testing.T) {
+	as := assert.New(t)
+
+	mockNowTime(t, time.Date(2016, time.December, 10, 0, 0, 0, 0, time.UTC))
+
+	metaData := []map[string]string{
+		{"x-amz-meta-fileName": "image1.png"},
+	}
+	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+		AWSAccessKeyID: "AWS_ACCESS_KEY_ID",
+		AWSSecretKeyID: "AWS_SECRET_KEY_ID",
+	}, s3gopolicy.UploadConfig{
+		BucketName:  "examplebucket",
+		ObjectKey:   "files/image1.png",
+		ContentType: "image/png",
+		FileSize:    2000,
+		MetaData:    metaData,
+	})
+	require.NoError(t, err)
+
+	as.Equal(metaData, policies.MetaData)
+
+	policyJSON, err := base64.StdEncoding.DecodeString(policies.Form.Policy)
+	require.NoError(t, err)
+	var policy struct {
+		Conditions []any `json:"conditions"`
+	}
+	require.NoError(t, json.Unmarshal(policyJSON, &policy))
+	as.Contains(policy.Conditions, map[string]any{"x-amz-meta-fileName": "image1.png"})
+}
+
 func TestCreatePoliciesDefaultUploadURL(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## 概要
v2でMetaDataを指定するとポリシーのconditionsには含まれる一方、フォームに含める手段がなく、ポリシー不一致でアップロードが拒否される問題を修正します。

Closes #8

## 変更内容
- `UploadPolicies` に `MetaData []map[string]string` フィールドを追加し、`CreatePolicies` で入力のMetaDataをそのまま返すようにした。呼び出し側は `Form` の各フィールドとあわせてこれらをフォームフィールドとして送信する
- 既存の `PoliciesForm` 構造体は変更せず、フィールド追加のみの非破壊的変更(v4のようにFormをmap化する案はbreaking changeになるため見送り)
- MetaDataがconditionsとUploadPoliciesの両方に含まれることを検証するテストを追加

## 動作確認
- `go test ./...` / `golangci-lint run ./...` パス