### PR TITLE
MinIOを使ったe2eテストを追加する

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
       - name: Start MinIO
         run: |
-          docker run -d --name minio -p 9000:9000 minio/minio server /data
+          docker run -d --name minio -p 9000:9000 minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           timeout 60 sh -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done'
-          docker run --rm --network host --entrypoint sh minio/mc -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/e2e-bucket"
+          docker run --rm --network host --entrypoint sh minio/mc:RELEASE.2025-08-13T08-35-41Z -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/e2e-bucket"
       - run: go test -tags e2e -run TestE2E -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,3 +20,18 @@ jobs:
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: profile.cov
+
+  e2e:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 minio/minio server /data
+          timeout 60 sh -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done'
+          docker run --rm --network host --entrypoint sh minio/mc -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/e2e-bucket"
+      - run: go test -tags e2e -run TestE2E -v ./...

--- a/README.md
+++ b/README.md
@@ -118,3 +118,28 @@ https://docs.aws.amazon.com/AmazonS3/latest/developerguide/UsingHTTPPOST.html
 ```shell
 go get github.com/kyokomi/s3gopolicy/v2
 ```
+
+## Testing
+
+```shell
+go test ./...
+```
+
+### E2E tests
+
+E2E tests upload to a local [MinIO](https://min.io/) server and are excluded from normal `go test` runs by the `e2e` build tag.
+
+```shell
+# Start MinIO and create the test bucket
+docker run -d --name minio -p 9000:9000 minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+docker run --rm --network host --entrypoint sh minio/mc:RELEASE.2025-08-13T08-35-41Z \
+  -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/e2e-bucket"
+
+# Run E2E tests
+go test -tags e2e -run TestE2E -v ./...
+
+# Cleanup
+docker rm -f minio
+```
+
+The endpoint, bucket, and credentials can be overridden with `S3GOPOLICY_E2E_ENDPOINT`, `S3GOPOLICY_E2E_BUCKET`, `S3GOPOLICY_E2E_ACCESS_KEY`, and `S3GOPOLICY_E2E_SECRET_KEY`.

--- a/v2/e2e_test.go
+++ b/v2/e2e_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+
+package s3gopolicy_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kyokomi/s3gopolicy/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func e2eEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
+	endpoint := e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000")
+	bucket := e2eEnv("S3GOPOLICY_E2E_BUCKET", "e2e-bucket")
+
+	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+		AWSAccessKeyID: e2eEnv("S3GOPOLICY_E2E_ACCESS_KEY", "minioadmin"),
+		AWSSecretKeyID: e2eEnv("S3GOPOLICY_E2E_SECRET_KEY", "minioadmin"),
+	}, s3gopolicy.UploadConfig{
+		UploadURL:   endpoint + "/" + bucket,
+		BucketName:  bucket,
+		ObjectKey:   "e2e/test-v2.txt",
+		ContentType: "text/plain",
+		FileSize:    int64(len(content)),
+	})
+	require.NoError(t, err)
+	return policies
+}
+
+func e2ePostForm(t *testing.T, url string, form s3gopolicy.PoliciesForm, content []byte) (int, string) {
+	fields := map[string]string{
+		"AWSAccessKeyId": form.AWSAccessKeyID,
+		"key":            form.ObjectKey,
+		"Content-Type":   form.ContentType,
+		"policy":         form.Policy,
+		"signature":      form.Signature,
+	}
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+	fw, err := w.CreateFormFile("file", "test-v2.txt")
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	req, err := http.NewRequest(http.MethodPost, url, &b)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return res.StatusCode, string(body)
+}
+
+func TestE2EUpload(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), 1024)
+	policies := e2eCreatePolicies(t, content)
+
+	status, body := e2ePostForm(t, policies.URL, policies.Form, content)
+	require.Equal(t, http.StatusNoContent, status, "upload should succeed: %s", body)
+}
+
+func TestE2EUploadRejectsTamperedSignature(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), 1024)
+	policies := e2eCreatePolicies(t, content)
+	policies.Form.Signature = "AAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+	status, body := e2ePostForm(t, policies.URL, policies.Form, content)
+	require.Equal(t, http.StatusForbidden, status, "tampered signature should be rejected: %s", body)
+}

--- a/v2/e2e_test.go
+++ b/v2/e2e_test.go
@@ -8,11 +8,15 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kyokomi/s3gopolicy/v2"
 	"github.com/stretchr/testify/require"
 )
+
+var e2eHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 func e2eEnv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
@@ -22,7 +26,9 @@ func e2eEnv(key, fallback string) string {
 }
 
 func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
-	endpoint := e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000")
+	t.Helper()
+
+	endpoint := strings.TrimSuffix(e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000"), "/")
 	bucket := e2eEnv("S3GOPOLICY_E2E_BUCKET", "e2e-bucket")
 
 	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
@@ -39,14 +45,8 @@ func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
 	return policies
 }
 
-func e2ePostForm(t *testing.T, url string, form s3gopolicy.PoliciesForm, content []byte) (int, string) {
-	fields := map[string]string{
-		"AWSAccessKeyId": form.AWSAccessKeyID,
-		"key":            form.ObjectKey,
-		"Content-Type":   form.ContentType,
-		"policy":         form.Policy,
-		"signature":      form.Signature,
-	}
+func e2eBuildForm(t *testing.T, fields map[string]string, content []byte) (io.Reader, string) {
+	t.Helper()
 
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
@@ -58,18 +58,31 @@ func e2ePostForm(t *testing.T, url string, form s3gopolicy.PoliciesForm, content
 	_, err = fw.Write(content)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
+	return &b, w.FormDataContentType()
+}
 
-	req, err := http.NewRequest(http.MethodPost, url, &b)
+func e2ePostForm(t *testing.T, url string, form s3gopolicy.PoliciesForm, content []byte) (int, string) {
+	t.Helper()
+
+	fields := map[string]string{
+		"AWSAccessKeyId": form.AWSAccessKeyID,
+		"key":            form.ObjectKey,
+		"Content-Type":   form.ContentType,
+		"policy":         form.Policy,
+		"signature":      form.Signature,
+	}
+	body, contentType := e2eBuildForm(t, fields, content)
+	req, err := http.NewRequest(http.MethodPost, url, body)
 	require.NoError(t, err)
-	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Content-Type", contentType)
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := e2eHTTPClient.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = res.Body.Close() }()
 
-	body, err := io.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
-	return res.StatusCode, string(body)
+	return res.StatusCode, string(resBody)
 }
 
 func TestE2EUpload(t *testing.T) {

--- a/v4/e2e_test.go
+++ b/v4/e2e_test.go
@@ -8,11 +8,15 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/kyokomi/s3gopolicy/v4"
 	"github.com/stretchr/testify/require"
 )
+
+var e2eHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
 func e2eEnv(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
@@ -22,7 +26,9 @@ func e2eEnv(key, fallback string) string {
 }
 
 func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
-	endpoint := e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000")
+	t.Helper()
+
+	endpoint := strings.TrimSuffix(e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000"), "/")
 	bucket := e2eEnv("S3GOPOLICY_E2E_BUCKET", "e2e-bucket")
 
 	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
@@ -43,7 +49,9 @@ func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
 	return policies
 }
 
-func e2ePostForm(t *testing.T, url string, fields map[string]string, content []byte) (int, string) {
+func e2eBuildForm(t *testing.T, fields map[string]string, content []byte) (io.Reader, string) {
+	t.Helper()
+
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 	for k, v := range fields {
@@ -54,18 +62,24 @@ func e2ePostForm(t *testing.T, url string, fields map[string]string, content []b
 	_, err = fw.Write(content)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
+	return &b, w.FormDataContentType()
+}
 
-	req, err := http.NewRequest(http.MethodPost, url, &b)
+func e2ePostForm(t *testing.T, url string, fields map[string]string, content []byte) (int, string) {
+	t.Helper()
+
+	body, contentType := e2eBuildForm(t, fields, content)
+	req, err := http.NewRequest(http.MethodPost, url, body)
 	require.NoError(t, err)
-	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Content-Type", contentType)
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := e2eHTTPClient.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = res.Body.Close() }()
 
-	body, err := io.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
-	return res.StatusCode, string(body)
+	return res.StatusCode, string(resBody)
 }
 
 func TestE2EUpload(t *testing.T) {
@@ -88,7 +102,6 @@ func TestE2EUploadRejectsTamperedSignature(t *testing.T) {
 func TestE2EUploadRejectsPolicyMismatch(t *testing.T) {
 	content := bytes.Repeat([]byte("a"), 1024)
 	policies := e2eCreatePolicies(t, content)
-	// content-length-rangeの条件(FileSizeと同一サイズ)に反するサイズで送る
 	tooLarge := bytes.Repeat([]byte("a"), 2048)
 
 	status, body := e2ePostForm(t, policies.URL, policies.Form, tooLarge)

--- a/v4/e2e_test.go
+++ b/v4/e2e_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+
+package s3gopolicy_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/kyokomi/s3gopolicy/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func e2eEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func e2eCreatePolicies(t *testing.T, content []byte) s3gopolicy.UploadPolicies {
+	endpoint := e2eEnv("S3GOPOLICY_E2E_ENDPOINT", "http://localhost:9000")
+	bucket := e2eEnv("S3GOPOLICY_E2E_BUCKET", "e2e-bucket")
+
+	policies, err := s3gopolicy.CreatePolicies(s3gopolicy.AWSCredentials{
+		Region:         "us-east-1",
+		AWSAccessKeyID: e2eEnv("S3GOPOLICY_E2E_ACCESS_KEY", "minioadmin"),
+		AWSSecretKeyID: e2eEnv("S3GOPOLICY_E2E_SECRET_KEY", "minioadmin"),
+	}, s3gopolicy.UploadConfig{
+		UploadURL:   endpoint + "/" + bucket,
+		BucketName:  bucket,
+		ObjectKey:   "e2e/test.txt",
+		ContentType: "text/plain",
+		FileSize:    int64(len(content)),
+		MetaData: map[string]string{
+			"x-amz-meta-fileName": "test.txt",
+		},
+	})
+	require.NoError(t, err)
+	return policies
+}
+
+func e2ePostForm(t *testing.T, url string, fields map[string]string, content []byte) (int, string) {
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	for k, v := range fields {
+		require.NoError(t, w.WriteField(k, v))
+	}
+	fw, err := w.CreateFormFile("file", "test.txt")
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	req, err := http.NewRequest(http.MethodPost, url, &b)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	return res.StatusCode, string(body)
+}
+
+func TestE2EUpload(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), 1024)
+	policies := e2eCreatePolicies(t, content)
+
+	status, body := e2ePostForm(t, policies.URL, policies.Form, content)
+	require.Equal(t, http.StatusNoContent, status, "upload should succeed: %s", body)
+}
+
+func TestE2EUploadRejectsTamperedSignature(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), 1024)
+	policies := e2eCreatePolicies(t, content)
+	policies.Form["X-Amz-Signature"] = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	status, body := e2ePostForm(t, policies.URL, policies.Form, content)
+	require.Equal(t, http.StatusForbidden, status, "tampered signature should be rejected: %s", body)
+}
+
+func TestE2EUploadRejectsPolicyMismatch(t *testing.T) {
+	content := bytes.Repeat([]byte("a"), 1024)
+	policies := e2eCreatePolicies(t, content)
+	// content-length-rangeの条件(FileSizeと同一サイズ)に反するサイズで送る
+	tooLarge := bytes.Repeat([]byte("a"), 2048)
+
+	status, body := e2ePostForm(t, policies.URL, policies.Form, tooLarge)
+	require.Equal(t, http.StatusBadRequest, status, "policy mismatch should be rejected: %s", body)
+}


### PR DESCRIPTION
## 概要
MinIOに対して実際にmultipart POSTを行い、生成した署名・ポリシーがS3互換サーバーに受理されることを検証するe2eテストを追加します。

Closes #14

## 変更内容
- `e2e` ビルドタグ付きのe2eテストを追加(v2/v4両方。MinIOはSigV2のPOST policyも検証できることを確認済み)
  - 正常系: アップロード成功(204)
  - 署名改ざん: 403で拒否
  - ポリシー不一致(content-length-range超過、v4のみ): 400で拒否
- CIにMinIOをdockerで起動してe2eテストを実行するジョブを追加
- 接続先は環境変数(`S3GOPOLICY_E2E_ENDPOINT` など)で上書き可能。デフォルトは `http://localhost:9000` / `e2e-bucket` / `minioadmin`

## ローカルでの実行方法
```shell
docker run -d --name minio -p 9000:9000 minio/minio server /data
docker run --rm --network host --entrypoint sh minio/mc -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/e2e-bucket"
go test -tags e2e -run TestE2E -v ./...
```

## 動作確認
- ローカルのMinIOに対してv2/v4の全e2eテストがパス
- `go test ./...`(通常テスト)/ `golangci-lint run --build-tags e2e ./...` パス