### PR TITLE
GitHub ActionsをNode.js 24対応バージョンに更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,17 +7,17 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - run: go version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
       - run: go test -v -coverprofile=profile.cov ./...
-      - uses: shogo82148/actions-goveralls@v1
+      - uses: shogo82148/actions-goveralls@9606dbc5ac5cf888a0e9ef901515c3cd516a2790 # v1.11.0
         with:
           path-to-profile: profile.cov
 
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Start MinIO

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,13 +7,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go version
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
       - run: go test -v -coverprofile=profile.cov ./...
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Start MinIO


### PR DESCRIPTION
## 概要
CIで「Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24」という警告が出ていたため、対象のactionをNode.js 24ベースの最新メジャーバージョンに更新します。あわせてサプライチェーン対策として全actionをコミットSHAで固定し、追従用にDependabotを導入します。

## 変更内容
- `actions/checkout` v4 → v7.0.0
- `actions/setup-go` v5 → v6.5.0
- `golangci/golangci-lint-action` v8 → v9.3.0
- 上記に加え `shogo82148/actions-goveralls`(v1.11.0)も含め、全actionをコミットSHA + バージョンコメントの形式で固定
- Dependabot(`package-ecosystem: github-actions`、週次)を追加。SHA固定のままバージョン追従のPRが自動作成される

build_and_test / e2e 両ジョブとも更新しています。